### PR TITLE
Update copyright to BAyPIGgies

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 
-AUTHOR = u'William Deegan'
+AUTHOR = u'Bay Area Python Interest Group (BAyPIGgies)'
 SITENAME = u'BayPIGgies Bay Area Python Interest Group'
 SITEURL = ''
 


### PR DESCRIPTION
The AUTHOR variable is used in templates to claim copyright. For example:
-                &copy; {{ YEAR }} {{ AUTHOR }} {{ LICENSE }}
-                &copy; {{ YEAR }} Bay Area Python Interest Group (BAyPIGgies) {{ LICENSE }}

Introducing another variable and modifying the template may be a better way of
handling this. For now, update AUTHOR to "Bay Area Python Interest Group
(BAyPIGgies)".
