### PR TITLE
Added November meeting and new FEATURED_ARTICLE setting

### DIFF
--- a/content/meetings/Meeting-2016-10-27.rst
+++ b/content/meetings/Meeting-2016-10-27.rst
@@ -8,7 +8,6 @@ Thursday, October 27nd, 2016 Meeting
 :slug: meeting-2016-10-27
 :authors: Jeff Fischer
 :summary: Python and IoT: From Chips and Bits to Data Science
-:save_as: index.html
 
 
 Register via Meetup.com here:

--- a/content/meetings/Meeting-2016-11-17.rst
+++ b/content/meetings/Meeting-2016-11-17.rst
@@ -1,0 +1,61 @@
+Thursday, November 17th, 2016 Meeting
+######################################
+
+:date: 2016-11-17 19:00
+:modified: 2016-10-28 17:00
+:tags: meeting, Django
+:category: meetings
+:slug: meeting-2016-11-17
+:authors: Jeff Fischer
+:summary: Django and Security
+:save_as: index.html
+
+
+Register via Meetup.com here:
+
+.. raw:: html
+
+  <a href="https://www.meetup.com/BAyPIGgies/events/232817003/" data-event="23281700" class="mu-rsvp-btn">RSVP</a>
+
+
+Note that we are having our meeting one week earlier than usual, due to Thanksgiving.
+
+Topic:
+  Django and Security
+
+Speaker:
+  James Bennett
+
+
+Abstract:
+ This talk will be a historical tour of the Django project's approach to security. We'll cover how Django's security policies have evolved over its eleven-year history, the ways the framework has integrated security as a major goal, and what we can learn from looking at patterns in the security issues that have occurred in Django. 
+
+
+Speaker Bio:
+ James has been using Django almost since the day it was publicly released, and a member of the Django core team since 2007. He currently serves on the Django security team and technical board, and as a Director of the Django Software Foundation. At his day job, James works to reinvent health insurance as part of the engineering team at Clover Health in San Francisco. 
+
+
+Meeting Schedule:
+  * 7:00 pm Networking
+  * 7:15 pm Announcements and presentation
+  * 8:45 pm Random access
+  * 9:00 pm Event ends
+
+
+Location:
+  LinkedIn
+
+  605 W. Maude Ave, Sunnyvale, CA.
+
+*Note that this is a new location.*
+
+
+Meeting Room:
+  Yosemite Room
+
+
+.. raw:: html
+
+  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s); js.id=id;js.async=true;js.src="https://a248.e.akamai.net/secure.meetupstatic.com/s/script/2012676015776998360572/api/mu.btns.js?id=km6g8p73etdt58eo9gj00n0q1f";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","mu-bootjs");</script>
+
+

--- a/content/meetings/Meeting-2016-11-17.rst
+++ b/content/meetings/Meeting-2016-11-17.rst
@@ -8,14 +8,13 @@ Thursday, November 17th, 2016 Meeting
 :slug: meeting-2016-11-17
 :authors: Jeff Fischer
 :summary: Django and Security
-:save_as: index.html
 
 
 Register via Meetup.com here:
 
 .. raw:: html
 
-  <a href="https://www.meetup.com/BAyPIGgies/events/232817003/" data-event="23281700" class="mu-rsvp-btn">RSVP</a>
+  <a href="https://www.meetup.com/BAyPIGgies/events/232817003/" data-event="232817003" class="mu-rsvp-btn">RSVP</a>
 
 
 Note that we are having our meeting one week earlier than usual, due to Thanksgiving.
@@ -56,6 +55,6 @@ Meeting Room:
 
 .. raw:: html
 
-  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s); js.id=id;js.async=true;js.src="https://a248.e.akamai.net/secure.meetupstatic.com/s/script/2012676015776998360572/api/mu.btns.js?id=km6g8p73etdt58eo9gj00n0q1f";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","mu-bootjs");</script>
+  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s); js.id=id;js.async=true;js.src="https://a248.e.akamai.net/secure.meetupstatic.com/s/script/2012676015776998360572/api/mu.btns.js?id=67qg1nm9sqh9jnrrcg2c20t2hm";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","mu-bootjs");</script>
 
 

--- a/featured.html
+++ b/featured.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block content %}
+    {% if articles %}
+    {% for article in (articles_page.object_list if articles_page else articles) %}
+      {% if article.title == FEATURED_ARTICLE %}
+        <article>
+            <header class="page-header">
+                <h1>
+                    <a href="{{ SITEURL }}/{{ article.url }}"
+                       rel="bookmark"
+                       title="Permalink to {{ article.title|striptags }}">
+                        {{ article.title }}
+                    </a>
+                </h1>
+            </header>
+            <div class="entry-content">
+                <div class="panel">
+                    <div class="panel-body">
+                        {% include "includes/article_info.html" %}
+                    </div>
+                </div>
+                {{ article.content }}
+            </div>
+            </article>
+            <hr/>
+	{% endif %} {# FEATURED_ARTICLE #}
+        {% endfor %}
+    {% endif %}
+
+    {% include 'includes/pagination.html' %}
+{% endblock content %}
+
+{% block canonical_rel %}<link rel="canonical" href="{{ SITEURL }}">{% endblock %}
+
+{% block banner %}
+	{% include 'includes/banner.html' %}
+{% endblock %}

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
+import os.path
 
 AUTHOR = u'Bay Area Python Interest Group (BAyPIGgies)'
 SITENAME = u'BayPIGgies Bay Area Python Interest Group'
@@ -46,3 +47,8 @@ BANNER_IMAGE='images/baypiggies.png'
 TWITTER_USER='baypiggies'
 # TWITTER_WIDGET_ID='598966848630169601'
 
+# The index.html page will be rendered from the featured.html template
+# in this directory.
+TEMPLATE_PAGES = {os.path.join(os.path.dirname(__file__), 'featured.html'): 'index.html'}
+# The title of the article to be featured on the home page
+FEATURED_ARTICLE = 'Thursday, November 17th, 2016 Meeting'


### PR DESCRIPTION
This pull request adds the description of the November meeting, along with a new meetup.com badge.

As mentioned in a private email, I ran into an issue that, if we use the save_as parameter for the latest meeting, the link to the meeting from the Meetings tab will be broken. There does not seem to be a clean way to instantiate the same page in two places via Pelican. My solution was to create a new index page that shows exactly one article, which is specified in the config file via the FEATURED_ARTICLE setting. This page is rendered via the new featured.html template. The page specific to the meeting is rendered as usual.
